### PR TITLE
refactor: Ignore malformed tags

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,27 +19,16 @@ pub fn latest_tag(path: &str) -> Option<Version> {
         Ok(repo) => repo,
         Err(_) => return None
     };
-    let mut biggest_tag = Version::parse("0.0.0").unwrap();
 
     let tags = match repo.tag_names(None) {
         Ok(tags) => tags,
         Err(_) => return None
     };
-    if tags.len() == 0 {
-        return None
-    }
-    for tag in tags.iter() {
-        let tag = tag.unwrap();
-        let tag = &tag[1..];
 
-        if let Ok(v) = Version::parse(tag) {
-            if v > biggest_tag {
-                biggest_tag = v;
-            }
-        }
-    }
-
-    Some(biggest_tag)
+    tags.iter()
+        .map(|tag| tag.unwrap())
+        .filter_map(|tag| Version::parse(&tag[1..]).ok())
+        .max()
 }
 
 pub fn version_bump_since_latest(path: &str) -> CommitType {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,9 +31,11 @@ pub fn latest_tag(path: &str) -> Option<Version> {
     for tag in tags.iter() {
         let tag = tag.unwrap();
         let tag = &tag[1..];
-        let v = Version::parse(tag).expect(&format!("Malformed tag {}", tag));
-        if v > biggest_tag {
-            biggest_tag = v;
+
+        if let Ok(v) = Version::parse(tag) {
+            if v > biggest_tag {
+                biggest_tag = v;
+            }
         }
     }
 


### PR DESCRIPTION
This shoud ignore unparseable tags as discussed in https://github.com/semantic-rs/semantic-rs/issues/19#issuecomment-174042449

Though right above we still have an unwrap and an indexing operation. Is it possible to have empty tags? If so we need to change that as well.

Do not merge before I verified it.
